### PR TITLE
Script to reverse the processed cosmo emissions onto a latlon grid

### DIFF
--- a/emiproc/__init__.py
+++ b/emiproc/__init__.py
@@ -96,13 +96,12 @@ def process_rotgrid(cfg, interpolation, country_mask, out, latname, lonname):
         for cat in cfg.categories:
             for var in cfg.species:
                 print('Species', var, 'Category', cat)
-
-                emi = cosmo_in[var]*cfg.input_grid.gridcell_areas().T
+                emi = cosmo_in[var]*(cfg.input_grid.gridcell_areas().T)
                 out_var = np.zeros((cfg.cosmo_grid.ny, cfg.cosmo_grid.nx))
                 for lon in range(np.shape(emi)[1]):
                     for lat in range(np.shape(emi)[0]):
                         for (x, y, r) in interpolation[lon, lat]:
-                            out_var[y, x] += emi[lon, lat] * r 
+                            out_var[y, x] += emi[lat, lon] * r 
 
                 cosmo_area = 1.0 / cfg.cosmo_grid.gridcell_areas()
 

--- a/emiproc/grids.py
+++ b/emiproc/grids.py
@@ -515,7 +515,7 @@ class SwissGrid(Grid):
 
 class COSMOGrid(Grid):
     """Class to manage a COSMO-domain
-    This grid is defined with a rotated pole coordinate system. 
+    This grid is defined as a rotated pole coordinate system. 
     The gridpoints are at the center of the cell.
     """
     

--- a/emiproc/grids.py
+++ b/emiproc/grids.py
@@ -94,7 +94,10 @@ class Grid:
 
 
 class TNOGrid(Grid):
-    """Contains the grid from the TNO emission inventory"""
+    """Contains the grid from the TNO emission inventory
+    This grid is defined as a standard lat/lon coordinate system. 
+    The gridpoints are at the center of the cell.
+    """
 
     def __init__(self, dataset_path, name="TNO"):
         """Open the netcdf-dataset and read the relevant grid information.
@@ -511,8 +514,11 @@ class SwissGrid(Grid):
 
 
 class COSMOGrid(Grid):
-    """Class to manage a COSMO-domain"""
-
+    """Class to manage a COSMO-domain
+    This grid is defined with a rotated pole coordinate system. 
+    The gridpoints are at the center of the cell.
+    """
+    
     nx: int
     ny: int
     dx: float
@@ -522,7 +528,7 @@ class COSMOGrid(Grid):
     pollon: float
     pollat: float
 
-    def __init__(self, nx, ny, dx, dy, xmin, ymin, pollon, pollat):
+    def __init__(self, nx, ny, dx, dy, xmin, ymin, pollon=180, pollat=90):
         """Store the grid information.
 
         Parameters


### PR DESCRIPTION
This is a PR to be able to process a COSMO emission inventory back into a different grid.
The use case scenario for this is for instance:
You have EDGAR emissions, you process them onto your COSMO grid. Then, for instsance, you make some inverse modelling and get a different emission inventory in a similar file format than your original COSMO emissions. You may want to transfer that back into a standard lat/lon grid again. 

[config_latlon.txt](https://github.com/C2SM-RCM/cosmo-emission-processing/files/3949588/config_latlon.txt)
