### PR TITLE
Use equal area Mollweide projection for computing fraction of overlap between inventory and model grid cells

### DIFF
--- a/emiproc/grids.py
+++ b/emiproc/grids.py
@@ -743,7 +743,6 @@ class COSMOGrid(Grid):
             # The inventory cell lies outside the cosmo grid
             return []
 
-        #inv_cell = Polygon(corners)
         molly = ccrs.Mollweide()
         corners = molly.transform_points(self.projection,corners[:,0],corners[:,1])
         inv_cell = Polygon(corners)
@@ -753,12 +752,10 @@ class COSMOGrid(Grid):
         # make sure we iterate only over valid gridpoint indices
         for i in range(max(0, lon_idx_min), min(self.nx, lon_idx_max)):
             for j in range(max(0, lat_idx_min), min(self.ny, lat_idx_max)):
-                corners = list(zip(*self.cell_corners(i, j)))
-                corners_arr = np.array(corners)
-                corners_bis = molly.transform_points(self.projection,corners_arr[:,0],corners_arr[:,1])
-                
-                #cosmo_cell = Polygon(corners)
-                cosmo_cell = Polygon(corners_bis)
+                corners = np.array(list(zip(*self.cell_corners(i, j))))
+                corners = molly.transform_points(self.projection,corners[:,0],corners[:,1])
+                                
+                cosmo_cell = Polygon(corners)
                 if cosmo_cell.intersects(inv_cell):
                     overlap = cosmo_cell.intersection(inv_cell)
                     intersections.append((i, j, overlap.area / inv_cell.area))

--- a/emiproc/grids.py
+++ b/emiproc/grids.py
@@ -743,14 +743,11 @@ class COSMOGrid(Grid):
             # The inventory cell lies outside the cosmo grid
             return []
 
-        # Here we assume a flat earth. The error is less than 1% for typical
-        # grid sizes over europe. Since we're interested in the ratio of areas,
-        # we can calculate in degrees^2.
-        lambconf = ccrs.LambertConformal()
-        corners_bis = lambconf.transform_points(self.projection,corners[:,0],corners[:,1])
-        inv_cell_bis = Polygon(corners_bis)
-
+        #inv_cell = Polygon(corners)
+        molly = ccrs.Mollweide()
+        corners = molly.transform_points(self.projection,corners[:,0],corners[:,1])
         inv_cell = Polygon(corners)
+
 
         intersections = []
         # make sure we iterate only over valid gridpoint indices
@@ -758,13 +755,12 @@ class COSMOGrid(Grid):
             for j in range(max(0, lat_idx_min), min(self.ny, lat_idx_max)):
                 corners = list(zip(*self.cell_corners(i, j)))
                 corners_arr = np.array(corners)
-                corners_bis = lambconf.transform_points(self.projection,corners_arr[:,0],corners_arr[:,1])
+                corners_bis = molly.transform_points(self.projection,corners_arr[:,0],corners_arr[:,1])
                 
-                cosmo_cell = Polygon(corners)
-                cosmo_cell_bis = Polygon(corners_bis)
+                #cosmo_cell = Polygon(corners)
+                cosmo_cell = Polygon(corners_bis)
                 if cosmo_cell.intersects(inv_cell):
                     overlap = cosmo_cell.intersection(inv_cell)
-                    overlap_bis = cosmo_cell_bis.intersection(inv_cell_bis)
-                    intersections.append((i, j, overlap.area / inv_cell.area, overlap_bis.area / inv_cell_bis.area))
+                    intersections.append((i, j, overlap.area / inv_cell.area))
 
         return intersections

--- a/emiproc/grids.py
+++ b/emiproc/grids.py
@@ -746,6 +746,10 @@ class COSMOGrid(Grid):
         # Here we assume a flat earth. The error is less than 1% for typical
         # grid sizes over europe. Since we're interested in the ratio of areas,
         # we can calculate in degrees^2.
+        lambconf = ccrs.LambertConformal()
+        corners_bis = lambconf.transform_points(self.projection,corners[:,0],corners[:,1])
+        inv_cell_bis = Polygon(corners_bis)
+
         inv_cell = Polygon(corners)
 
         intersections = []
@@ -753,10 +757,14 @@ class COSMOGrid(Grid):
         for i in range(max(0, lon_idx_min), min(self.nx, lon_idx_max)):
             for j in range(max(0, lat_idx_min), min(self.ny, lat_idx_max)):
                 corners = list(zip(*self.cell_corners(i, j)))
+                corners_arr = np.array(corners)
+                corners_bis = lambconf.transform_points(self.projection,corners_arr[:,0],corners_arr[:,1])
+                
                 cosmo_cell = Polygon(corners)
-
+                cosmo_cell_bis = Polygon(corners_bis)
                 if cosmo_cell.intersects(inv_cell):
                     overlap = cosmo_cell.intersection(inv_cell)
-                    intersections.append((i, j, overlap.area / inv_cell.area))
+                    overlap_bis = cosmo_cell_bis.intersection(inv_cell_bis)
+                    intersections.append((i, j, overlap.area / inv_cell.area, overlap_bis.area / inv_cell_bis.area))
 
         return intersections


### PR DESCRIPTION
Compute the fraction of the intersected area in the equal-area Mollweide projection.
Potentially, we want to avoid projecting the inventory cell onto the rotated pole grid first, then again onto the Mollweide.
However, this is not a costly step. Moreover, we already project all the corners of each cell individually, which is also wasteful since a corner belongs to 4 cells, so we project it 4 times.